### PR TITLE
Update DOCS.md

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -66,6 +66,8 @@ Now it is time to set up Home Assistant:
 1. Go to the Settings panel and click "Devices & Services".
 1. In the bottom right, click "+ Add Integration".
 1. Select the "Z-Wave" integration from the list.
+   - You may need to choose "Setup another instance of Z-Wave" if the add-on
+     has been auto-detected as a device.
 1. A dialog box will show, asking to use the add-on:
    - **UNCHECK** that box, it will install the official add-on.
    - Again, the official add-on is recommended, so...


### PR DESCRIPTION
In Home Assistant 2022.10.1, step 4 under "Now it is time to set up Home Assistant:" can be confusing depending on whether Home Assistant has auto-detected this add-on as a Z-Wave device.

# Proposed Changes

>  Add a bullet to help explain this scenario.
