### PR TITLE
Remove duplicate reference to Zwave js ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Some advantages and use-cases:
 
 This add-on uses the [Z-Wave JS UI][zwave-js-ui] software.
 
-This add-on uses the [Z-Wave JS UI][zwave-js-ui] software.
-
 [:books: Read the full add-on documentation][docs]
 
 ## Support


### PR DESCRIPTION
# Proposed Changes

Remove a duplicate instance of the line `This add-on uses the Z-Wave JS UI software.`

## Related Issues
N/A