### PR TITLE
Bump python3-dev=3.10.10-r0, nodejs=18.14.1-r0

### DIFF
--- a/zwave-js-ui/Dockerfile
+++ b/zwave-js-ui/Dockerfile
@@ -12,13 +12,13 @@ RUN \
         build-base=0.5-r3 \
         linux-headers=5.19.5-r0 \
         npm=9.1.2-r0 \
-        python3-dev=3.10.9-r1 \
+        python3-dev=3.10.10-r0 \
     \
     && apk add --no-cache \
         eudev=3.2.11-r4 \
         libusb=1.0.26-r0 \
         nginx=1.22.1-r0 \
-        nodejs=18.12.1-r0 \
+        nodejs=18.14.1-r0 \
     \
     && npm install --global yarn@2.4.3 \
     \


### PR DESCRIPTION
# Proposed Changes

Bumps python3-dev to 3.10.10-r0 and nodejs to 18.14.1-r0 due to Alpine 3.17 updates.
  * https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.17
  * https://pkgs.alpinelinux.org/packages?name=python3-dev&branch=v3.17


## Related PR

> #467 