### PR TITLE
Extend timeout on shutdown

### DIFF
--- a/zwave-js-ui/Dockerfile
+++ b/zwave-js-ui/Dockerfile
@@ -5,6 +5,11 @@ FROM ${BUILD_FROM}
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# Environment configuration
+ENV \
+    S6_KILL_GRACETIME=30000 \
+    S6_SERVICES_GRACETIME=30000
+
 # Setup base
 ARG ZWAVE_JS_UI_VERSION="v8.19.0"
 # hadolint ignore=DL3003,SC2046

--- a/zwave-js-ui/config.yaml
+++ b/zwave-js-ui/config.yaml
@@ -11,6 +11,7 @@ panel_title: Z-Wave JS
 panel_icon: mdi:z-wave
 startup: system
 init: false
+timeout: 30
 arch:
   - aarch64
   - amd64


### PR DESCRIPTION
# Proposed Changes

Based on feedback received, it seems like the add-on sometimes shuts down / is killed too quickly, causing it to be killed while not done writing cache files yet.

This PR extends the default gracetime from 3 to 30 seconds.

../Frenck
