### PR TITLE
Update DOCS.md

### DIFF
--- a/zwave-js-ui/DOCS.md
+++ b/zwave-js-ui/DOCS.md
@@ -70,7 +70,7 @@ Now it is time to set up Home Assistant:
    - **UNCHECK** that box, it will install the official add-on.
    - Again, the official add-on is recommended, so...
 1. In the next dialog it will ask for the server. Enter:
-   `ws://a0d7b954-zwavejs2mqtt:3000`
+   `ws://a0d7b954-zwavejs2mqtt:3000` literally. You enter this exact value no matter what machine you are running on despite that seeming strange.
 1. Confirm and done!
 
 ## Configuration


### PR DESCRIPTION
Added note that you literally enter that value for step 5 because that seems quite odd.

# Proposed Changes

When reading this instructions, the literal in step 5 seems quite strange given that one is running on a new installation. So this clarifies that indeed one uses that exact literal.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified instructions for setting up Home Assistant with Z-Wave JS, specifically regarding the WebSocket server address.
	- Enhanced user understanding to ensure accurate setup following the instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->